### PR TITLE
Add countdown subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ All commands support the following flags:
 
 Start streaming:
 
-```bash
+```
 obs-cli stream start
 ```
 
 Stop streaming:
 
-```bash
+```
 obs-cli stream stop
 ```
 
@@ -54,19 +54,19 @@ obs-cli stream stop
 
 Start recording:
 
-```bash
+```
 obs-cli recording start
 ```
 
 Stop recording:
 
-```bash
+```
 obs-cli recording stop
 ```
 
 Toggle recording:
 
-```bash
+```
 obs-cli recording toggle
 ```
 
@@ -74,7 +74,7 @@ obs-cli recording toggle
 
 Switch to a scene:
 
-```bash
+```
 obs-cli scene switch <scene>
 ```
 
@@ -82,39 +82,45 @@ obs-cli scene switch <scene>
 
 Change a FreeType text label:
 
-```bash
+```
 obs-cli label text <label> <text>
+```
+
+Trigger a countdown and continuously update a label with the remaining time:
+
+```
+obs-cli label countdown <label> <duration>
 ```
 
 ### Scene Items
 
 List all items of a scene:
 
-```bash
+```
 obs-cli sceneitem list <scene>
 ```
 
 Make a scene-item visible:
 
-```bash
+```
 obs-cli sceneitem show <scene> <item>
 ```
 
 Hide a scene-item:
 
-```bash
+```
 obs-cli sceneitem hide <scene> <item>
 ```
 
 Toggle visibility of a scene-item:
 
-```bash
+```
 obs-cli sceneitem toggle <scene> <item>
 ```
 
 Center a scene-item horizontally:
 
-```bash
+```
 obs-cli sceneitem center <scene> <item>
 ```
 
@@ -122,12 +128,12 @@ obs-cli sceneitem center <scene> <item>
 
 List special sources:
 
-```bash
+```
 obs-cli source list
 ```
 
 Toggle mute status of a source:
 
-```bash
+```
 obs-cli source toggle-mute <source>
 ```

--- a/countdown.go
+++ b/countdown.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var countdownCmd = &cobra.Command{
+	Use:   "countdown",
+	Short: "Triggers a countdown and continuously updates a label with the remaining time",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 2 {
+			return errors.New("countdown requires a label and the countdown in seconds")
+		}
+
+		d, err := time.ParseDuration(args[1])
+		if err != nil {
+			return err
+		}
+
+		return countdown(args[0], d)
+	},
+}
+
+func countdown(label string, duration time.Duration) error {
+	until := time.Now().Add(duration).Add(time.Second)
+
+	c := time.Tick(time.Second)
+	for range c {
+		rem := time.Until(until)
+		if rem < 0 {
+			rem = 0
+		}
+		if err := changeLabel(label, fmtDuration(rem)); err != nil {
+			return err
+		}
+
+		if time.Now().After(until) {
+			break
+		}
+	}
+
+	return nil
+}
+
+func fmtDuration(d time.Duration) string {
+	d = d.Round(time.Second)
+	m := d % time.Hour / time.Minute
+	s := d % time.Minute / time.Second
+	return fmt.Sprintf("%02d:%02d", m, s)
+}
+
+func init() {
+	labelCmd.AddCommand(countdownCmd)
+}


### PR DESCRIPTION
Adds a `label countdown` command that will run a countdown, continuously updating a label with the remaining time.