### PR TITLE
Support switching the preview in studio mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,19 @@ obs-cli recording status
 
 ### Scenes
 
-Switch to a scene:
+Switch program to a scene:
+
+```
+obs-cli scene current <scene>
+```
+
+Switch preview to a scene (studio mode must be enabled):
+
+```
+obs-cli scene preview <scene>
+```
+
+Switch program (studio mode disabled) or preview (studio mode enabled) to a scene:
 
 ```
 obs-cli scene switch <scene>

--- a/scene.go
+++ b/scene.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/andreykaipov/goobs/api/requests/scenes"
+	"github.com/andreykaipov/goobs/api/requests/studio_mode"
 	"github.com/spf13/cobra"
 )
 
@@ -16,9 +17,31 @@ var (
 		RunE:  nil,
 	}
 
+	currentSceneCmd = &cobra.Command{
+		Use:   "current",
+		Short: "Switch program to a different scene",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("current requires a scene name as argument")
+			}
+			return setCurrentScene(strings.Join(args, " "))
+		},
+	}
+
+	previewSceneCmd = &cobra.Command{
+		Use:   "preview",
+		Short: "Switch preview to a different scene (studio mode must be enabled)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("preview requires a scene name as argument")
+			}
+			return setPreviewScene(strings.Join(args, " "))
+		},
+	}
+
 	switchSceneCmd = &cobra.Command{
 		Use:   "switch",
-		Short: "Switch to a different scene",
+		Short: "Switch program or preview in studio mode to a different scene",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("switch requires a scene name as argument")
@@ -28,7 +51,7 @@ var (
 	}
 )
 
-func switchScene(scene string) error {
+func setCurrentScene(scene string) error {
 	r := scenes.SetCurrentSceneParams{
 		SceneName: scene,
 	}
@@ -36,7 +59,29 @@ func switchScene(scene string) error {
 	return err
 }
 
+func setPreviewScene(scene string) error {
+	r := studiomode.SetPreviewSceneParams{
+		SceneName: scene,
+	}
+	_, err := client.StudioMode.SetPreviewScene(&r)
+	return err
+}
+
+func switchScene(scene string) error {
+	isStudioModeEnabled, err := IsStudioModeEnabled()
+	if err != nil {
+		return err
+	}
+
+	if isStudioModeEnabled {
+		return setPreviewScene(scene)
+	}
+	return setCurrentScene(scene)
+}
+
 func init() {
+	sceneCmd.AddCommand(currentSceneCmd)
+	sceneCmd.AddCommand(previewSceneCmd)
 	sceneCmd.AddCommand(switchSceneCmd)
 	rootCmd.AddCommand(sceneCmd)
 }

--- a/studiomode.go
+++ b/studiomode.go
@@ -67,13 +67,19 @@ func enableStudioMode() error {
 	return err
 }
 
-func studioModeStatus() error {
+// Determine if the studio mode is currently enabled in OBS.
+func IsStudioModeEnabled() (bool, error) {
 	r, err := client.StudioMode.GetStudioModeStatus()
+	return r.StudioMode, err
+}
+
+func studioModeStatus() error {
+	isStudioModeEnabled, err := IsStudioModeEnabled()
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Studio Mode: %s\n", strconv.FormatBool(r.StudioMode))
+	fmt.Printf("Studio Mode: %s\n", strconv.FormatBool(isStudioModeEnabled))
 	return nil
 }
 


### PR DESCRIPTION
`scene switch` always changes the program, but I expect it to change the preview in case the studio mode is enabled.

So change `scene switch` to switch the preview (if studio mode is enabled) or the program (if studio mode is disabled). Add `scene current` for always changing the program scene and add `scene preview` to always change the preview scene (which requires studio mode to be enabled).

The naming and the description could be improved, but I failed coming up with better names.