### PR TITLE
Set client name and version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/muesli/obs-cli
 go 1.13
 
 require (
-	github.com/andreykaipov/goobs v0.6.0
+	github.com/andreykaipov/goobs v0.7.2-0.20211128070100-3f68e679c844
 	github.com/dustin/go-humanize v1.0.0
 	github.com/spf13/cobra v0.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,12 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/andreykaipov/goobs v0.6.0 h1:qTZBh8fw9HlwfqdLKAWUGhgPsPSiGEosQNrBFmlQPm0=
-github.com/andreykaipov/goobs v0.6.0/go.mod h1:PsbaqYzrYfbPcXhzI/VltZRekmU8cw3ydCGvFYaUFZA=
+github.com/andreykaipov/goobs v0.7.2-0.20211128070100-3f68e679c844 h1:qvPC/v/GLyBKyfuYmzRmc8nkW6Iu0kZYWWq7N+w2g5w=
+github.com/andreykaipov/goobs v0.7.2-0.20211128070100-3f68e679c844/go.mod h1:LUUc1aXWR0B6HrwKC2LE+JtW85aiYInXeowv4AtzGvY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -31,7 +32,9 @@ github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb6
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -39,3 +42,4 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/andreykaipov/goobs"
@@ -12,6 +13,7 @@ var (
 	host     string
 	password string
 	port     uint32
+	version  string
 
 	rootCmd = &cobra.Command{
 		Use:   "obs-cli",
@@ -39,9 +41,21 @@ func init() {
 	rootCmd.PersistentFlags().Uint32VarP(&port, "port", "p", 4444, "port to connect to")
 }
 
+func getUserAgent() string {
+	userAgent := "obs-cli"
+	if version != "" {
+		userAgent += "/" + version
+	}
+	return userAgent
+}
+
 func connectOBS() {
 	var err error
-	client, err = goobs.New(host+fmt.Sprintf(":%d", port), goobs.WithPassword(password))
+	client, err = goobs.New(
+		host+fmt.Sprintf(":%d", port),
+		goobs.WithPassword(password),
+		goobs.WithRequestHeader(http.Header{"User-Agent": []string{getUserAgent()}}),
+	)
 	if err != nil {
 		fmt.Println("error:", err)
 		os.Exit(1)


### PR DESCRIPTION
goobs from 2021-11-28 (next release after 0.7.1) introduced `WithRequestHeader` to set the cient name and version.

So set the client name to `obs-cli` and an empty version. To set the version number, specify the version as linker flag:

```
go build -ldflags="-X main.version=0.2.0"
```

Closes https://github.com/muesli/obs-cli/issues/26