### PR TITLE
Add profile management

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,23 @@ Transition to program (when the studio mode is enabled):
 ```
 obs-cli studiomode transition
 ```
+
+### Profiles
+
+List all profiles:
+
+```
+obs-cli profile list
+```
+
+Show the current profile:
+
+```
+obs-cli profile get
+```
+
+Switch to a profile:
+
+```
+obs-cli profile set <profile>
+```

--- a/profile.go
+++ b/profile.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/andreykaipov/goobs/api/requests/profiles"
+	"github.com/spf13/cobra"
+)
+
+var (
+	profileCmd = &cobra.Command{
+		Use:   "profile",
+		Short: "manage profiles",
+		Long:  `The profile command manages profiles`,
+		RunE:  nil,
+	}
+
+	listProfileCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List all profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listProfiles()
+		},
+	}
+
+	getProfileCmd = &cobra.Command{
+		Use:   "get",
+		Short: "Get the current profile",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return getProfile()
+		},
+	}
+
+	setProfileCmd = &cobra.Command{
+		Use:   "set",
+		Short: "Set the current profile",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return errors.New("set requires a profile name as argument")
+			}
+			return setProfile(strings.Join(args, " "))
+		},
+	}
+)
+
+func listProfiles() error {
+	r, err := client.Profiles.ListProfiles()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range r.Profiles {
+		fmt.Println(v.ProfileName)
+	}
+	return nil
+}
+
+func setProfile(profile string) error {
+	r := profiles.SetCurrentProfileParams{
+		ProfileName: profile,
+	}
+	_, err := client.Profiles.SetCurrentProfile(&r)
+	return err
+}
+
+func getProfile() error {
+	r, err := client.Profiles.GetCurrentProfile()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(r.ProfileName)
+	return nil
+}
+
+func init() {
+	profileCmd.AddCommand(listProfileCmd)
+	profileCmd.AddCommand(setProfileCmd)
+	profileCmd.AddCommand(getProfileCmd)
+	rootCmd.AddCommand(profileCmd)
+}


### PR DESCRIPTION
This adds the following commands:

```
obs-cli profile list
obs-cli profile get
obs-cli profile set
```

Fixes #36.